### PR TITLE
RouteCollection is in Routing package

### DIFF
--- a/routing/collection.md
+++ b/routing/collection.md
@@ -13,6 +13,7 @@ Here is an example of a route collection for the `v1` portion of an API.
 ```swift
 import Vapor
 import HTTP
+import Routing
 
 class V1Collection: RouteCollection {
     typealias Wrapped = HTTP.Responder


### PR DESCRIPTION
When following along, Xcode could't resolve `RouteCollection`. After jumping through some packages, I realized that it's in `Routing`.