### PR TITLE
Typo for a file in the example

### DIFF
--- a/guide/config.md
+++ b/guide/config.md
@@ -13,7 +13,7 @@ For Vapor applications, configuration files are expected to be nested under a to
 ```bash
 ./
 ├── Config/
-│   ├── server.json
+│   ├── servers.json
 ```
 
 And an example of how this might look:


### PR DESCRIPTION
Found a typo for the ./Config/servers.json file.
It was spelled `server.json`