### PR TITLE
Add explanation to import HTTP module

### DIFF
--- a/guide/controllers.md
+++ b/guide/controllers.md
@@ -25,7 +25,7 @@ Simple controllers don't need to conform to any protocols. You are free to desig
 
 ### Registering
 
-The only required structure is the signature of each method in the controller. In order to register this method into the router, it must have a signature like `(Request) throws -> ResponseRepresentable`.
+The only required structure is the signature of each method in the controller. In order to register this method into the router, it must have a signature like `(Request) throws -> ResponseRepresentable`. `Request` and `ResponseRepresentable` are made available by importing the `HTTP` module.
 
 ```swift
 let hc = HelloController()


### PR DESCRIPTION
## Rationale

When going through the Vapor Docs step-by-step, one could go through the guide in sequence, starting at `Droplet` and eventually reaching `Controller`. In `Controller` under the **Registering** section, it states the following:

> In order to register this method into the router, it must have a signature like `(Request) throws -> ResponseRepresentable`.

At this point in the guide, one is not yet exposed to `Request` and `ResponseRespresentable` which are included in the `HTTP` module. One might expect that the class and protocol respectively might be included in the `Vapor` module, but this is not the case. This can be an inconvenience, especially for beginners as the code would not compile.

By explaining that `Request` and `ResponseRepresentable` are parts of the `HTTP` module and that importing them is required, there would be less chance of the reader and learner getting lost.

_Long live Vapor!_