### PR TITLE
[BasicRouting] hyperlinks `Method` to 'response.md'

### DIFF
--- a/routing/basic.md
+++ b/routing/basic.md
@@ -42,7 +42,7 @@ You can also use `/`, but commas are often easier to type and work better with t
 
 ## Alternate
 
-An alternate syntax that accepts a `Method` as the first parameter is also available.
+An alternate syntax that accepts a [`Method`](../http/response.md) as the first parameter is also available.
 
 ```swift
 drop.add(.trace, "welcome") { request in


### PR DESCRIPTION
Quality-of-life change. 

> _Although, would've preferred to have been able to jump directly to `response.html#Method`. Not sure if Markdown can support that with relative links._