### PR TITLE
Added Flock and VaporFlock to package list

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,6 +66,8 @@ Here are a list of providers and third party packages that work great with Vapor
 - [APNS](https://github.com/matthijs2704/vapor-apns): Simple APNS Library for Vapor (Swift).
 - [JWT](https://github.com/siemensikkema/vapor-jwt): JWT implementation for Vapor.
 - [VaporS3Signer](https://github.com/JustinM1/VaporS3Signer): Generate V4 Auth Header/Pre-Signed URL for AWS S3 REST API
+- [Flock](https://github.com/jakeheis/Flock): Automated deployment of Swift projects to servers
+	- [VaporFlock](https://github.com/jakeheis/VaporFlock): Use Flock to deploy Vapor applications
 
 
 ## Authors


### PR DESCRIPTION
Following the suggestion of @LoganWright, I've added Flock and VaporFlock to the list of third party packages which work well with Vapor.