### PR TITLE
Websocket documentation

### DIFF
--- a/websockets/droplet.md
+++ b/websockets/droplet.md
@@ -29,7 +29,7 @@ drop.socket("ws") { req, ws in
 
         // reverse the characters and send back
         let rev = String(text.characters.reversed())
-        try ws.send(rev.bytes)
+        try ws.send(rev)
     }
 
     ws.onClose = { ws, code, reason, clean in
@@ -51,7 +51,9 @@ ws.onmessage = function(msg) {
     console.log(msg)
 }
 
-ws.send("test")
+ws.onopen = function(event) {
+    ws.send("test")
+}
 ```
 
 The above will log `tset` (`test` reversed).


### PR DESCRIPTION
You don't want to send the byte array to a javascript client.

Also added ws.onopen to the js example to have a ready-to-go example