### PR TITLE
Correct links to GitHub searches

### DIFF
--- a/fluent/driver.md
+++ b/fluent/driver.md
@@ -13,8 +13,8 @@ This graphic shows the relation between Drivers and Providers using MySQL as an 
 If you want to use Fluent without Vapor, you will import Drivers into your package. If you are using Vapor, you will import Providers.
 
 Search GitHub for:
-- [Fluent Drivers](https://github.com/vapor?utf8=✓&query=-driver)
-- [Vapor Providers](https://github.com/vapor?utf8=✓&query=-provider)
+- [Fluent Drivers](https://github.com/vapor?utf8=✓&q=-driver)
+- [Vapor Providers](https://github.com/vapor?utf8=✓&q=-provider)
 
 Not all drivers have providers yet, and not all drivers or providers are up to date with the latest Vapor 1.0. This is a great way to contribute!
 

--- a/guide/provider.md
+++ b/guide/provider.md
@@ -12,7 +12,7 @@ Adding a provider to your application takes 2-3 steps.
 
 ### Add Package
 
-All of Vapor's providers end with the `-provider` syntax. You can see a list of [available providers](https://github.com/vapor?utf8=✓&query=-provider) by searching on our GitHub.
+All of Vapor's providers end with the `-provider` syntax. You can see a list of [available providers](https://github.com/vapor?utf8=✓&q=-provider) by searching on our GitHub.
 
 To add the provider to your package, add it as a dependency in your `Package.swift` file.
 


### PR DESCRIPTION
This makes links to GitHub searches work properly, used e.g. on Fluent driver page.

GitHub uses GET parameter named “q” instead of “query” on project search pages. Perhaps they’ve renamed it at some point after the initial version of relevant Vapor docs was complete. 