### PR TITLE
Remove duplicate reference to html-leaf plugin

### DIFF
--- a/guide/leaf.md
+++ b/guide/leaf.md
@@ -171,19 +171,15 @@ And use it just like we did [above](#index).
 [language-leaf](https://atom.io/packages/language-leaf) by ButkiewiczP
 
 ### Xcode
+
 It is not currently possible to implement Leaf Syntax Highlighting in Xcode, however, using Xcode's HTML Syntax Coloring can help a bit. Select one or more Leaf files and then choose Editor > Syntax Coloring > HTML.  Your selected Leaf files will now use Xcode's HTML Syntax Coloring.  Unfortunately the usefulness of this is limited because this association will be removed when `vapor xcode` is run.
 
 There appears to be a way to [make Xcode file associations persist](http://stackoverflow.com/questions/9050035/how-to-make-xcode-recognize-a-custom-file-extension-as-objective-c-for-syntax-hi) but that requires a bit more kung-fu.
 
+### VS Code
 
-### Visual Studio Code
-
-[vscode-html-leaf](https://marketplace.visualstudio.com/items?itemName=Francisco.html-leaf) by FranciscoAmado
+[html-leaf](https://marketplace.visualstudio.com/items?itemName=Francisco.html-leaf) by FranciscoAmado
 
 ### CLion & AppCode
 
 Some preliminary work has been done to implement a Leaf Plugin for CLion & AppCode but lack of skill and interest in Java has slowed progress! If you have IntelliJ SDK experience and want to help with this, message Tom Holland on [Vapor Slack](http://vapor.team)
-
-### VS Code
-
-[html-leaf](https://marketplace.visualstudio.com/items?itemName=Francisco.html-leaf) by FranciscoAmado

--- a/routing/collection.md
+++ b/routing/collection.md
@@ -17,7 +17,7 @@ import Routing
 
 class V1Collection: RouteCollection {
     typealias Wrapped = HTTP.Responder
-    func build<B: RouteBuilder>(_ builder: B) {
+    func build<B: RouteBuilder where B.Value == Wrapped>(_ builder: B) {
         let v1 = builder.grouped("v1")
         let users = v1.grouped("users")
         let articles = v1.grouped("articles")

--- a/routing/collection.md
+++ b/routing/collection.md
@@ -17,7 +17,7 @@ import Routing
 
 class V1Collection: RouteCollection {
     typealias Wrapped = HTTP.Responder
-    func build<B: RouteBuilder where B.Value == Wrapped>(_ builder: B) {
+    func build<B: RouteBuilder>(_ builder: B) {
         let v1 = builder.grouped("v1")
         let users = v1.grouped("users")
         let articles = v1.grouped("articles")


### PR DESCRIPTION
`vscode-html-leaf`plugin and `html-leaf`plugin are same.