### PR TITLE
Download shell scripts through HTTPS (requires vapor.sh server config fix!)

### DIFF
--- a/getting-started/install-swift-3-macos.md
+++ b/getting-started/install-swift-3-macos.md
@@ -21,7 +21,7 @@ After Xcode 8 has been downloaded, you must open it to finish the installation. 
 Double check the installation was successful by running:
 
 ```sh
-curl -sL check.vapor.sh | bash
+curl -sL https://check.vapor.sh | bash
 ```
 
 ## Toolbox

--- a/getting-started/install-swift-3-ubuntu.md
+++ b/getting-started/install-swift-3-ubuntu.md
@@ -11,7 +11,7 @@ Installing Swift 3 on Ubuntu only takes a couple of minutes.
 Don't want to type? Run the following script to quickly install Swift 3.0.
 
 ```sh
-curl -sL swift.vapor.sh/ubuntu | bash
+curl -sL https://swift.vapor.sh/ubuntu | bash
 ```
 
 > Note: The install script adds Swift to your `~/.bashrc` profile automatically.
@@ -86,7 +86,7 @@ export PATH=/swift-3.0/usr/bin:"${PATH}"
 Double check the installation was successful by running:
 
 ```sh
-curl -sL check.vapor.sh | bash
+curl -sL https://check.vapor.sh | bash
 ```
 
 ## Toolbox

--- a/getting-started/install-toolbox.md
+++ b/getting-started/install-toolbox.md
@@ -15,7 +15,7 @@ Vapor's command line interface provides shortcuts and assistance for common task
 Run the following script to install the [Toolbox](https://github.com/vapor/toolbox).
 
 ```sh
-curl -sL toolbox.vapor.sh | bash
+curl -sL https://toolbox.vapor.sh | bash
 ```
 
 > Note: You must have the correct version of Swift 3 installed.

--- a/getting-started/manual.md
+++ b/getting-started/manual.md
@@ -17,7 +17,7 @@ This document assumes that you have Swift 3 installed.
 To check that your environment is compatible, run the following script:
 
 ```bash
-curl -sL check.vapor.sh | bash
+curl -sL https://check.vapor.sh | bash
 ```
 
 ## Make new project using SwiftPM


### PR DESCRIPTION
In several places in the docs, users are instructed to download a shell script and pipe it straight to `bash`:

    curl -sL check.vapor.sh | bash
    curl -sL toolbox.vapor.sh | bash
    curl -sL swift.vapor.sh/ubuntu | bash

While this is pretty and easy to remember, it also causes the initial connection to vapor.sh to be made insecurely through HTTP. A man-in-the-middle attack could intercept the connection and respond with a malicious shell script that would then be executed by bash.

Changing the commands to 

    curl -sL https://check.vapor.sh | bash
    curl -sL https://toolbox.vapor.sh | bash
    curl -sL https://swift.vapor.sh/ubuntu | bash

will cause the connecion to be made through HTTPS.

Unfortunately, only swift.vapor.sh seems to have a working SSL configuration at this time. The "check" and "toolbox" subdomains use the certificate for swift.vapor.sh and return a HTTP 500 error if connecting anyway. **This needs to be fixed before this pull request can be merged.**