### PR TITLE
Updated collection.md to reflect latest swift syntax

### DIFF
--- a/1.5/routing/collection.md
+++ b/1.5/routing/collection.md
@@ -17,7 +17,7 @@ import Routing
 
 class V1Collection: RouteCollection {
     typealias Wrapped = HTTP.Responder
-    func build<B: RouteBuilder where B.Value == Wrapped>(_ builder: B) {
+    func build<B: RouteBuilder>(_ builder: B) where B.Value == Wrapped {
         let v1 = builder.grouped("v1")
         let users = v1.grouped("users")
         let articles = v1.grouped("articles")

--- a/1.5/routing/collection.md
+++ b/1.5/routing/collection.md
@@ -53,7 +53,7 @@ typealias Wrapped = HTTP.Responder
 This limits our route collection to adding HTTP responders. While the underlying router is capable of routing any type, Vapor routes HTTP responders exclusively. If we want to use this route collection with Vapor, it's wrapped type needs to match.
 
 ```swift
-func build<B: RouteBuilder where B.Value == Wrapped>(_ builder: B) {
+func build<B: RouteBuilder>(_ builder: B) where B.Value == Wrapped {
 ```
 
 This method accepts a route builder and also verifies that the route builder accepts `Wrapped` or, as defined in the last line, `HTTP.Responder`s. Vapor's `Droplet` and any route [group](group.md) created with Vapor are `RouteBuilder`s that accept HTTP responders.


### PR DESCRIPTION
While attempting to write my first Collection in Vapor, Xcode 8.3.2 gave me the following warning `'where' clause next to generic parameters is deprecated and will be removed in the future version of Swift`, with a suggestion on how to update the syntax.