### PR TITLE
Added documentation on how to add validation packages

### DIFF
--- a/2.0/docs/validation/package.md
+++ b/2.0/docs/validation/package.md
@@ -1,0 +1,43 @@
+# Using Validation
+
+This section outlines how to import the Validation package both with or without a Vapor project.
+
+## With Vapor
+
+The easiest way to use Validation with Vapor is to include the Validation provider. 
+
+```swift
+import PackageDescription
+
+let package = Package(
+    name: "Project",
+    dependencies: [
+        .Package(url: "https://github.com/vapor/vapor.git", majorVersion: 2),
+        .Package(url: "https://github.com/vapor/validation-provider.git", majorVersion: 1)
+    ],
+    exclude: [ ... ]
+)
+```
+
+The Validation provider package adds Validation to your project and adds some additional, vapor-specific conveniences like validation middleware. 
+
+Using `import ValidationProvider` will import the Validation middleware and the Validation module. 
+
+## Just Validation
+
+At the core of the Validation provider is a Validation module.
+
+```swift
+import PackageDescription
+
+let package = Package(
+    name: "Project",
+    dependencies: [
+        ...
+        .Package(url: "https://github.com/vapor/validation.git", majorVersion: 1)
+    ],
+    exclude: [ ... ]
+)
+```
+
+Use `import Validation` to access the core validation class.


### PR DESCRIPTION
At the moment the validation-provider package name is still VaporValidation. However it is renamed to ValidationProvider in patch-3 of the package but not yet released.

Since this is a bug and the fix will be released very soon I guess I considered using the right name here in the documentation already :)