### PR TITLE
Make validation/package.md accessible on https://docs.vapor.codes/2.0/

### DIFF
--- a/2.0/mkdocs.yml
+++ b/2.0/mkdocs.yml
@@ -73,7 +73,9 @@ pages:
     - 'Package': 'leaf/package.md'
     - 'Provider': 'leaf/provider.md'
     - 'Overview': 'leaf/leaf.md'
-- Validation: 'validation/overview.md'
+- Validation:
+    - 'Package': 'validation/package.md'
+    - 'Overview': 'validation/overview.md'
 - Node:
     - 'Package': 'node/package.md'
     - 'Getting Started': 'node/getting-started.md'


### PR DESCRIPTION
We now have documentation about "validation/package.md" but it's yet not accessible through the menu on "https://docs.vapor.codes/2.0/".

This PR should solve that :)