### PR TITLE
Fix incorrect function name in sample code

### DIFF
--- a/2.0/docs/http/client.md
+++ b/2.0/docs/http/client.md
@@ -48,7 +48,7 @@ req.formURLEncoded = Node(node: [
     "email": "mymail@vapor.codes"
 ])
 
-try drop.client.response(to: req)
+try drop.client.respond(to: req)
 ```
 
 ## Re-usable Connection


### PR DESCRIPTION
There is no function named `response` in the `ClientProtocol`.
It should be `respond`.