### PR TITLE
Fix syntax error for idType

### DIFF
--- a/2.0/docs/fluent/model.md
+++ b/2.0/docs/fluent/model.md
@@ -289,7 +289,7 @@ This value should be overriden if a particular model in your database uses a dif
 
 ```swift
 final class Pet: Model {
-    static let idType = .uuid
+    static let idType: IdentifierType = .uuid
 }
 ```
 


### PR DESCRIPTION
Fix the error "Reference to member 'uuid' cannot be resolved without a contextual type"