### PR TITLE
fix AllCapsLogger example for Vapor 2

### DIFF
--- a/2.0/docs/vapor/droplet.md
+++ b/2.0/docs/vapor/droplet.md
@@ -166,15 +166,15 @@ final class AllCapsLogger: LogProtocol {
     }
 
     func log(_ level: LogLevel, message: String, file: String, function: String, line: Int) {
-        print(message.uppercased + String(repeating: "!", count: exclamationCount))
+        print(message.uppercased() + String(repeating: "!", count: exclamationCount))
     }
 }
 
 extension AllCapsLogger: ConfigInitializable {
-   init(config: Config) throws {
+    convenience init(config: Config) throws {
         let count = config["allCaps", "exclamationCount"]?.int ?? 3
         self.init(exclamationCount: count)
-   } 
+    } 
 }
 ```
 
@@ -184,13 +184,11 @@ extension AllCapsLogger: ConfigInitializable {
 Now that we have conformed our logger to `ConfigInitializable`, we can pass just the type name to `addConfigurable`.
 
 
-`main.swift`
+`Config+Setup.swift`
 ```swift
-let config = try Config()
-config.addConfigurable(log: AllCapsLogger.self, name: "all-caps")
-
-let drop = try Droplet(config)
-
+public func setup() throws {
+    addConfigurable(log: AllCapsLogger.init, name: "all-caps")
+}
 ```
 
 Now if you add a file named `allCaps.json` to the `Config` folder, you can configure the logger.


### PR DESCRIPTION
fix the AllCapsLogger example in Vapor/Droplet section.
