### PR TITLE
fix AllCapsLogger example for vapor2

### DIFF
--- a/2.0/docs/vapor/droplet.md
+++ b/2.0/docs/vapor/droplet.md
@@ -120,20 +120,24 @@ Let's create a custom logger to demonstrate Vapor's configurable properties.
 final class AllCapsLogger: LogProtocol {
     var enabled: [LogLevel] = []
     func log(_ level: LogLevel, message: String, file: String, function: String, line: Int) {
-        print(message.uppercased + "!!!")
+        print(message.uppercased() + "!!!")
     }
+}
+
+extension AllCapsLogger: ConfigInitializable {
+    convenience init(config: Config) throws {
+        self.init()
+    } 
 }
 ```
 
 Now add the logger to the Droplet using the `addConfigurable` method for logs.
 
-`main.swift`
+`Config+Setup.swift`
 ```swift
-let config = try Config()
-config.addConfigurable(log: AllCapsLogger(), name: "all-caps")
-
-let drop = try Droplet(config)
-
+public func setup() throws {
+    addConfigurable(log: AllCapsLogger.init, name: "all-caps")
+}
 ```
 
 Whenever the `"log"` property is set to `"all-caps"` in the `droplet.json`, our new logger will be used. 
@@ -166,15 +170,15 @@ final class AllCapsLogger: LogProtocol {
     }
 
     func log(_ level: LogLevel, message: String, file: String, function: String, line: Int) {
-        print(message.uppercased + String(repeating: "!", count: exclamationCount))
+        print(message.uppercased() + String(repeating: "!", count: exclamationCount))
     }
 }
 
 extension AllCapsLogger: ConfigInitializable {
-   init(config: Config) throws {
+    convenience init(config: Config) throws {
         let count = config["allCaps", "exclamationCount"]?.int ?? 3
         self.init(exclamationCount: count)
-   } 
+    } 
 }
 ```
 
@@ -184,13 +188,11 @@ extension AllCapsLogger: ConfigInitializable {
 Now that we have conformed our logger to `ConfigInitializable`, we can pass just the type name to `addConfigurable`.
 
 
-`main.swift`
+`Config+Setup.swift`
 ```swift
-let config = try Config()
-config.addConfigurable(log: AllCapsLogger.self, name: "all-caps")
-
-let drop = try Droplet(config)
-
+public func setup() throws {
+    addConfigurable(log: AllCapsLogger.init, name: "all-caps")
+}
 ```
 
 Now if you add a file named `allCaps.json` to the `Config` folder, you can configure the logger.

--- a/2.0/docs/vapor/droplet.md
+++ b/2.0/docs/vapor/droplet.md
@@ -133,12 +133,12 @@ extension AllCapsLogger: ConfigInitializable {
 
 Now add the logger to the Droplet using the `addConfigurable` method for logs.
 
-`Config+Setup.swift`
 ```swift
-public func setup() throws {
-    addConfigurable(log: AllCapsLogger.init, name: "all-caps")
-}
+addConfigurable(log: AllCapsLogger.init, name: "all-caps")
 ```
+
+!!! note
+    This should be added in `Config+Setup.swift` in templates with that file.
 
 Whenever the `"log"` property is set to `"all-caps"` in the `droplet.json`, our new logger will be used. 
 
@@ -187,13 +187,12 @@ extension AllCapsLogger: ConfigInitializable {
 
 Now that we have conformed our logger to `ConfigInitializable`, we can pass just the type name to `addConfigurable`.
 
-
-`Config+Setup.swift`
 ```swift
-public func setup() throws {
-    addConfigurable(log: AllCapsLogger.init, name: "all-caps")
-}
+addConfigurable(log: AllCapsLogger.init, name: "all-caps")
 ```
+
+!!! note
+    This should be added in `Config+Setup.swift` in templates with that file.
 
 Now if you add a file named `allCaps.json` to the `Config` folder, you can configure the logger.
 


### PR DESCRIPTION
in Vapor/Droplet section

If I put init AllCapsLogger in main.swift, then I get `main.swift:21:29: Use of unresolved identifier 'AllCapsLogger'`. so I move this init to Config+Setup.swift.

When there is no ConfigInitializable init, then i get `Cannot convert value of type '() -> AllCapsLogger' to expected argument type '(Config) -> (_)'`, so I added this extension.
