### PR TITLE
Make Verify Swift Installation more explicit

### DIFF
--- a/2.0/docs/getting-started/install-on-macos.md
+++ b/2.0/docs/getting-started/install-on-macos.md
@@ -14,7 +14,7 @@ After Xcode 8 has been downloaded, you must open it to finish the installation. 
 
 ## Verify Swift Installation
 
-Double check the installation was successful by running:
+Double check the installation was successful by opening Terminal and running:
 
 ```sh
 eval "$(curl -sL check.vapor.sh)"


### PR DESCRIPTION
I figured that you were talking about running the command in Terminal, however I was unsure because the previous step left off with opening Xcode.