### PR TITLE
Add upgrade to getting started

### DIFF
--- a/2.0/docs/getting-started/install-on-macos.md
+++ b/2.0/docs/getting-started/install-on-macos.md
@@ -53,6 +53,15 @@ Now that you've added Vapor's tap, you can install Vapor's toolbox and dependenc
 brew install vapor
 ```
 
+### Upgrade
+
+If you've previously installed Vapor upgrades to Homebrew and Vapor may be required to work with the latest versions of macOS, Swift, or the instructions in this guide.
+
+```sh
+brew update
+brew upgrade vapor
+```
+
 ## Next
 
 Learn more about the Vapor toolbox CLI in the [Toolbox section](toolbox.md) of the Getting Started section.


### PR DESCRIPTION
It’s not always obvious how to use Homebrew and users might get stuck trying to “get started” again if they’ve tried Vapor in the past and experienced a breaking change.