### PR TITLE
Update install instructions.

### DIFF
--- a/2.0/docs/getting-started/install-on-macos.md
+++ b/2.0/docs/getting-started/install-on-macos.md
@@ -50,7 +50,7 @@ brew update
 Now that you've added Vapor's tap, you can install Vapor's toolbox and dependencies.
 
 ```sh
-brew install vapor
+brew install vapor/tap/vapor
 ```
 
 ### Upgrade

--- a/2.0/docs/getting-started/install-on-macos.md
+++ b/2.0/docs/getting-started/install-on-macos.md
@@ -36,18 +36,9 @@ If you don't already have Homebrew installed, install it! It's incredibly useful
 
 For more information on installing Homebrew, visit [brew.sh](https://brew.sh).
 
-### Add Homebrew Tap
-
-Vapor's Homebrew tap will give your Homebrew installation access to all of Vapor's macOS packages.
-
-```sh
-brew tap vapor/homebrew-tap
-brew update
-```
-
 ### Install
 
-Now that you've added Vapor's tap, you can install Vapor's toolbox and dependencies.
+Now you can install Vapor's toolbox and dependencies.
 
 ```sh
 brew install vapor/tap/vapor


### PR DESCRIPTION
With the latest version of brew on MacOS 10.13.1 I get:
`Error: No available formula with the name "vapor"`

`brew install vapor/tap/vapor` works fine

source: https://stackoverflow.com/a/43071459/573938