### PR TITLE
Add warning about missing template

### DIFF
--- a/3.0/docs/getting-started/hello-world.md
+++ b/3.0/docs/getting-started/hello-world.md
@@ -16,6 +16,8 @@ vapor new Hello
 
 !!! warning
 	Make sure to add `--branch=beta` while using Vapor 3 pre-release.
+	
+	If you receive an error that looks like this:  'Cloning Template [Failed]' then the template you are using is not           yet ready for the beta branch. Try a different template. 
 
 Once that finishes, change into the newly created directory.
 


### PR DESCRIPTION
Hopefully this will stave off some initial confusion when someone tries to use a template that doesn't have a beta branch in its repo.w