### PR TITLE
Update SQLite package

### DIFF
--- a/3.0/docs/databases/sqlite/package.md
+++ b/3.0/docs/databases/sqlite/package.md
@@ -19,7 +19,7 @@ let package = Package(
     name: "Project",
     dependencies: [
         ...
-        .package(url: "https://github.com/vapor/fluent-sqlite.git", .upToNextMajor(from: "3.0.0")),
+        .package(url: "https://github.com/vapor/fluent.git", .branch("beta")),
     ],
     targets: [
       .target(name: "Project", dependencies: ["FluentSQLite", ... ])


### PR DESCRIPTION
The sqlite driver package is no longer necessary to import `FluentSQLite`