### PR TITLE
fixed 3.0 edit uri

### DIFF
--- a/3.0/mkdocs.yml
+++ b/3.0/mkdocs.yml
@@ -125,7 +125,7 @@ theme:
     logo: 'images/droplet-white.svg'
 
 repo_url: http://github.com/vapor/vapor
-edit_uri: https://github.com/vapor/documentation/edit/fluent/3.0/docs/
+edit_uri: https://github.com/vapor/documentation/edit/vapor3/3.0/docs/
 extra:
     social:
         - type: 'twitter'


### PR DESCRIPTION
I've fixed the edit uri for the 3.0 docs. 

If this is ever merged into master: change `https://github.com/vapor/documentation/edit/vapor3/3.0/docs/` -> `https://github.com/vapor/documentation/edit/master/3.0/docs/`

Relevant issue: #280 