### PR TITLE
Feature/update swift 4.1

### DIFF
--- a/2.0/docs/auth/package.md
+++ b/2.0/docs/auth/package.md
@@ -4,7 +4,15 @@ This section outlines how to import the Auth package both with or without a Vapo
 
 ## With Vapor
 
-The easiest way to use Auth with Vapor is to include the Auth provider. 
+The easiest way to use Auth with Vapor is to include the Auth provider.
+
+You can achieve this by running:
+
+```bash
+vapor provider add auth
+```
+
+or by manually modifying your `Package.swift` file:
 
 ```swift
 import PackageDescription
@@ -21,11 +29,13 @@ let package = Package(
 
 The Auth provider package adds Auth to your project and adds some additional, vapor-specific conveniences like auth middleware. 
 
+After you added the dependency, fetch it using `vapor update`.
+
 Using `import AuthProvider` will import all of the auth middleware and the Authentication and Authorization modules. 
 
-## Just Auth
+## Without Vapor
 
-At the core of the Auth provider is an Authentication and Authorization module based on Fluent.
+At the core of the Vapor Auth provider is an Authentication and Authorization module based on Fluent, which you can use as a stand-alone package by including the Auth in your `Package.swift` files:
 
 ```swift
 import PackageDescription
@@ -39,5 +49,7 @@ let package = Package(
     exclude: [ ... ]
 )
 ```
+
+After you added the dependency, fetch it using `vapor update`.
 
 Use `import Auth` to access the core auth classes.

--- a/2.0/docs/auth/provider.md
+++ b/2.0/docs/auth/provider.md
@@ -4,10 +4,10 @@ After you've [added the Auth Provider package](package.md) to your project, sett
 
 ## Add to Droplet
 
-Register the `AuthProvider.Provider` with your Droplet.
+Register the `AuthProvider.Provider` with your Droplet in your `Config+Setup.swift` file:
 
 ```swift
-import Vapor
+import App
 import AuthProvider
 
 let config = try Config()

--- a/2.0/docs/getting-started/install-on-macos.md
+++ b/2.0/docs/getting-started/install-on-macos.md
@@ -1,16 +1,18 @@
 # Install on macOS
 
-To use Vapor on macOS, you just need to have Xcode 8 installed.
+To use Vapor on macOS, you just need to have Xcode 8 or later installed.
 
 ## Install Xcode
 
-Install [Xcode 8](https://itunes.apple.com/us/app/xcode/id497799835?mt=12) from the Mac App Store.
+Install [Xcode 9](https://itunes.apple.com/us/app/xcode/id497799835?mt=12) from the Mac App Store.
 
-[![Xcode 8](https://cloud.githubusercontent.com/assets/1342803/18537674/2ddd8e9c-7ad5-11e6-9bc2-7155d57d20ec.png)](https://itunes.apple.com/us/app/xcode/id497799835?mt=12)
+[![Xcode 9](https://cloud.githubusercontent.com/assets/1342803/18537674/2ddd8e9c-7ad5-11e6-9bc2-7155d57d20ec.png)](https://itunes.apple.com/us/app/xcode/id497799835?mt=12)
+
+(Xcode 8 is the minimum required to use Vapor 2.0 on macOS. If you have an Apple Developer membership you can download older versions of Xcode from Apple's developer [downloads page](https://developer.apple.com/download/more/))
 
 ### Open Xcode
 
-After Xcode 8 has been downloaded, you must open it to finish the installation. This may take a while.
+After Xcode has been downloaded, you must open it to finish the installation. This may take a while.
 
 ## Verify Swift Installation
 
@@ -22,7 +24,7 @@ eval "$(curl -sL check.vapor.sh)"
 
 ## Install Vapor
 
-Now that you have Swift 3.1, let's install the Vapor toolbox. 
+Now that you have Swift 4 (or Swift 3.1 if you installed Xcode 8), let's install the Vapor toolbox. 
 
 The toolbox includes all of Vapor's dependencies as well as a handy CLI tool for creating new projects.
 
@@ -68,4 +70,4 @@ Learn more about the Vapor toolbox CLI in the [Toolbox section](toolbox.md) of t
 
 ## Swift.org
 
-Check out [Swift.org](https://swift.org)'s extensive guides if you need more detailed instructions for installing Swift 3.1.
+Check out [Swift.org](https://swift.org)'s extensive guides if you need more detailed instructions for installing Swift.

--- a/2.0/docs/getting-started/install-on-macos.md
+++ b/2.0/docs/getting-started/install-on-macos.md
@@ -53,6 +53,15 @@ Now that you've added Vapor's tap, you can install Vapor's toolbox and dependenc
 brew install vapor
 ```
 
+### Upgrade
+
+If you've previously installed Vapor upgrades to Homebrew and Vapor may be required to work with the latest versions of macOS, Swift, or the instructions in this guide.
+
+```sh
+brew update
+brew upgrade vapor
+```
+
 ## Next
 
 Learn more about the Vapor toolbox CLI in the [Toolbox section](toolbox.md) of the Getting Started section.

--- a/2.0/docs/getting-started/toolbox.md
+++ b/2.0/docs/getting-started/toolbox.md
@@ -20,7 +20,7 @@ vapor --help
 
 The `vapor run` command is a special toolbox command that forwards to your Vapor application.
 
-You can use `vapor run serve` to boot your application, or `vapor run help` to view all available application-level commands. This includes custom commands you may have added to your application.
+Once you've built your application with `vapor build` you can use `vapor run serve` to boot your application, or `vapor run help` to view all available application-level commands. This includes custom commands you may have added to your application.
 
 !!! warning
 	Using `vapor run --help` will provide information about the `run` command itself and will not forward to your Vapor application.

--- a/2.0/docs/leaf/leaf.md
+++ b/2.0/docs/leaf/leaf.md
@@ -52,7 +52,7 @@ The double token: `##` indicates a chain. It can be applied to any standard Tag.
 #### Token: `#()`
 
 ```
-#() #()hashtags #()FTW => # #Hashtags #FTW
+#() #()hashtags #()FTW => # #hashtags #FTW
 ```
 
 #### Raw: `#raw() {}`

--- a/2.0/docs/routing/collection.md
+++ b/2.0/docs/routing/collection.md
@@ -28,7 +28,7 @@ class V1Collection: RouteCollection {
 }
 ```
 
-This class could be place in any file, and we could add it to our droplet or even another route group.
+This class could be placed in any file, and we could add it to our droplet or even another route group.
 
 ```swift
 let v1 = V1Collection()

--- a/2.0/docs/validation/overview.md
+++ b/2.0/docs/validation/overview.md
@@ -1,5 +1,8 @@
-!!! warning
-    This section may contain outdated information.
+!!! error "Work in Progress"
+    The subject of this page is Work in Progress and is not recommended for Production use.
+
+!!! error "Outdated"
+    This page contains outdated information.
 
 # Validation
 

--- a/2.0/docs/validation/package.md
+++ b/2.0/docs/validation/package.md
@@ -1,3 +1,9 @@
+!!! error "Work in Progress"
+    The subject of this page is Work in Progress and is not recommended for Production use.
+
+!!! error "Outdated"
+    This page contains outdated information.
+
 # Using Validation
 
 This section outlines how to import the Validation package both with or without a Vapor project.

--- a/2.0/docs/vapor/controllers.md
+++ b/2.0/docs/vapor/controllers.md
@@ -35,7 +35,7 @@ let hc = HelloController()
 drop.get("hello", handler: hc.sayHello)
 ```
 
-Since the signature of our `sayHello` method matches the signature of the closure for the `drop.get` method, we can pass it directly.
+Since the signature of our `sayHello` method matches the signature of the closure for the `drop.get` method, we can pass it directly. If you want to test it locally simply open [http://localhost:8080/hello?name=John](http://localhost:8080/hello?name=John).
 
 ### Type Safe
 
@@ -45,7 +45,7 @@ You can also use controller methods with type-safe routing.
 final class HelloController {
 	...
 
-	func sayHelloAlternate(_ req: Request) -> ResponseRepresentable {
+	func sayHelloAlternate(_ req: Request) throws -> ResponseRepresentable {
         let name: String = try req.parameters.next(String.self)
 		return "Hello, \(name)"
 	}
@@ -59,7 +59,7 @@ let hc = HelloController()
 drop.get("hello", String.parameter, handler: hc.sayHelloAlternate)
 ```
 
-Since `drop.get` accepts a signature `(Request) throws -> ResponseRepresentable`, our method can now be used as the closure for this route. 
+Since `drop.get` accepts a signature `(Request) throws -> ResponseRepresentable`, our method can now be used as the closure for this route. In this case to test it locally open [http://localhost:8080/hello/John](http://localhost:8080/hello/John).
 
 !!! note 
     Read more about type safe routing in the [Routing Parameters](https://docs.vapor.codes/2.0/routing/parameters/#type-safe) section.

--- a/2.0/mkdocs.yml
+++ b/2.0/mkdocs.yml
@@ -76,7 +76,7 @@ pages:
     - 'Package': 'leaf/package.md'
     - 'Provider': 'leaf/provider.md'
     - 'Overview': 'leaf/leaf.md'
-- Validation:
+- Validation (WIP):
     - 'Package': 'validation/package.md'
     - 'Overview': 'validation/overview.md'
 - Node:

--- a/3.0/docs/install/macos.md
+++ b/3.0/docs/install/macos.md
@@ -1,6 +1,6 @@
 # Install on macOS
 
-To use Vapor on macOS, you just need to have Xcode 9 or greater installed.
+To use Vapor on macOS, you just need to have Xcode 9.3 or greater installed.
 
 !!! tip
     You need to install Xcode to install Swift, but after that you can use any text editor 
@@ -8,12 +8,15 @@ To use Vapor on macOS, you just need to have Xcode 9 or greater installed.
 
 ## Install Xcode
 
-Install [Xcode 9 or greater](https://itunes.apple.com/us/app/xcode/id497799835?mt=12) from the Mac App Store.
+Install [Xcode 9.3 or greater](https://itunes.apple.com/us/app/xcode/id497799835?mt=12) from the Mac App Store.\*
 
 <img width="1112" alt="Xcode 9.1" src="https://user-images.githubusercontent.com/1342803/32911091-1b55b434-cad9-11e7-8ab2-fbd7ea0084da.png">
 
 !!! warning
     After Xcode has been downloaded, you must open it to finish the installation. This may take a while.
+
+!!! warning
+    \*While Xcode 9.3 is still in beta it can only be downloaded from [Apple Developer Download page](https://developer.apple.com/download/). After installation, run the following command in the terminal: `sudo xcode-select -s /Applications/Xcode-beta.app`.
 
 ### Verify Installation
 
@@ -26,15 +29,15 @@ swift --version
 You should see output similar to:
 
 ```sh
-Apple Swift version 4.0.2 (swiftlang-900.0.69.2 clang-900.0.38)
-Target: x86_64-apple-macosx10.9
+Apple Swift version 4.1 (swiftlang-902.0.34 clang-902.0.30)
+Target: x86_64-apple-darwin17.4.0
 ```
 
-Vapor requires Swift 4.
+Vapor requires Swift 4.1.
 
 ## Install Vapor
 
-Now that you have Swift 4, let's install the [Vapor Toolbox](../getting-started/toolbox.md).
+Now that you have Swift 4.1, let's install the [Vapor Toolbox](../getting-started/toolbox.md).
 
 The toolbox includes all of Vapor's dependencies as well as a handy CLI tool for creating new projects.
 

--- a/3.0/docs/install/ubuntu.md
+++ b/3.0/docs/install/ubuntu.md
@@ -45,11 +45,14 @@ sudo apt-get update
 
 ## Install Vapor
 
-Now that you have added Vapor's APT repo, you can install the required dependencies.
+Now that you have added Vapor's APT repo, you can install the required dependencies.\*
 
 ```sh
 sudo apt-get install swift vapor
 ```
+
+!!! warning
+	\*While swift 4.1 is still in development it can be downloaded from https://swift.org/download/#swift-41-development.
 
 ### Verify Installation
 
@@ -64,11 +67,11 @@ swift --version
 You should see output similar to:
 
 ```sh
-Apple Swift version 4.0.2 (swiftlang-900.0.69.2 clang-900.0.38)
-Target: x86_64-apple-macosx10.9
+Apple Swift version 4.1 (swiftlang-902.0.34 clang-902.0.30)
+Target: x86_64-apple-darwin17.4.0
 ```
 
-Vapor requires Swift 4.
+Vapor requires Swift 4.1.
 
 #### Vapor Toolbox
 
@@ -84,4 +87,4 @@ Now that you have installed Vapor, create your first app in [Getting Started &ra
 
 ## Swift.org
 
-Check out [Swift.org](https://swift.org)'s guide to [using downloads](https://swift.org/download/#using-downloads) if you need more detailed instructions for installing Swift 4.
+Check out [Swift.org](https://swift.org)'s guide to [using downloads](https://swift.org/download/#using-downloads) if you need more detailed instructions for installing Swift 4.1.


### PR DESCRIPTION
I tried to update the installation instructions as much as possible to reflect the dependency on Swift 4.1.

To do after Xcode 9.3 and Swift 4.1 are released:
- Update App Store image
- Update output of `swift --version`
- remove all warning text boxes related to Swift 4.1 being in development

Ideally the output for `swift --version` on Ubuntu should match the actual output on Ubuntu.