### PR TITLE
Update install docs to reflect xcode 9.3/swift 4.1

### DIFF
--- a/3.0/docs/install/macos.md
+++ b/3.0/docs/install/macos.md
@@ -1,6 +1,6 @@
 # Install on macOS
 
-To use Vapor on macOS, you just need to have Xcode 9 or greater installed.
+To use Vapor on macOS, you just need to have Xcode 9.3 or greater installed.
 
 !!! tip
     You need to install Xcode to install Swift, but after that you can use any text editor 
@@ -8,12 +8,15 @@ To use Vapor on macOS, you just need to have Xcode 9 or greater installed.
 
 ## Install Xcode
 
-Install [Xcode 9 or greater](https://itunes.apple.com/us/app/xcode/id497799835?mt=12) from the Mac App Store.
+Install [Xcode 9.3 or greater](https://itunes.apple.com/us/app/xcode/id497799835?mt=12) from the Mac App Store.\*
 
 <img width="1112" alt="Xcode 9.1" src="https://user-images.githubusercontent.com/1342803/32911091-1b55b434-cad9-11e7-8ab2-fbd7ea0084da.png">
 
 !!! warning
     After Xcode has been downloaded, you must open it to finish the installation. This may take a while.
+
+!!! warning
+    \*While Xcode 9.3 is still in beta it can only be downloaded from [Apple Developer Download page](https://developer.apple.com/download/). After installation, run the following command in the terminal: `sudo xcode-select -s /Applications/Xcode-beta.app`.
 
 ### Verify Installation
 
@@ -26,15 +29,15 @@ swift --version
 You should see output similar to:
 
 ```sh
-Apple Swift version 4.0.2 (swiftlang-900.0.69.2 clang-900.0.38)
-Target: x86_64-apple-macosx10.9
+Apple Swift version 4.1 (swiftlang-902.0.34 clang-902.0.30)
+Target: x86_64-apple-darwin17.4.0
 ```
 
-Vapor requires Swift 4.
+Vapor requires Swift 4.1.
 
 ## Install Vapor
 
-Now that you have Swift 4, let's install the [Vapor Toolbox](../getting-started/toolbox.md).
+Now that you have Swift 4.1, let's install the [Vapor Toolbox](../getting-started/toolbox.md).
 
 The toolbox includes all of Vapor's dependencies as well as a handy CLI tool for creating new projects.
 

--- a/3.0/docs/install/ubuntu.md
+++ b/3.0/docs/install/ubuntu.md
@@ -45,11 +45,14 @@ sudo apt-get update
 
 ## Install Vapor
 
-Now that you have added Vapor's APT repo, you can install the required dependencies.
+Now that you have added Vapor's APT repo, you can install the required dependencies.\*
 
 ```sh
 sudo apt-get install swift vapor
 ```
+
+!!! warning
+	\*While swift 4.1 is still in development it can be downloaded from https://swift.org/download/#swift-41-development.
 
 ### Verify Installation
 
@@ -64,11 +67,11 @@ swift --version
 You should see output similar to:
 
 ```sh
-Apple Swift version 4.0.2 (swiftlang-900.0.69.2 clang-900.0.38)
-Target: x86_64-apple-macosx10.9
+Swift version 4.1-dev (LLVM 4d75b446be, Clang db92199adc, Swift 990b05adc6)
+Target: x86_64-unknown-linux-gnu
 ```
 
-Vapor requires Swift 4.
+Vapor requires Swift 4.1.
 
 #### Vapor Toolbox
 
@@ -84,4 +87,4 @@ Now that you have installed Vapor, create your first app in [Getting Started &ra
 
 ## Swift.org
 
-Check out [Swift.org](https://swift.org)'s guide to [using downloads](https://swift.org/download/#using-downloads) if you need more detailed instructions for installing Swift 4.
+Check out [Swift.org](https://swift.org)'s guide to [using downloads](https://swift.org/download/#using-downloads) if you need more detailed instructions for installing Swift 4.1.


### PR DESCRIPTION
I tried to update the installation instructions as much as possible to reflect the dependency on Swift 4.1.

To do after Xcode 9.3 and Swift 4.1 are released:
- Update App Store image
- Update output of swift --version
- remove all warning text boxes related to Swift 4.1 being in development