### PR TITLE
Specify rc.2 for FluentPostgreSQL package

### DIFF
--- a/3.0/docs/postgresql/fluent.md
+++ b/3.0/docs/postgresql/fluent.md
@@ -23,7 +23,7 @@ let package = Package(
         /// Any other dependencies ...
         
         // 🖋🐘 Swift ORM (queries, models, relations, etc) built on PostgreSQL.
-        .package(url: "https://github.com/vapor/fluent-postgresql.git", from: "1.0.0-rc"),
+        .package(url: "https://github.com/vapor/fluent-postgresql.git", from: "1.0.0-rc.2"),
     ],
     targets: [
         .target(name: "App", dependencies: ["FluentPostgreSQL", ...]),


### PR DESCRIPTION
The first rc was not compatible with vapor-rc.2