### PR TITLE
Fix example code in Command doc

### DIFF
--- a/3.0/docs/command/overview.md
+++ b/3.0/docs/command/overview.md
@@ -110,7 +110,7 @@ struct CowsayCommand: Command {
     ...
     
     /// See `Command`.
-    func run(using context: CommandContext) throws -> Future {
+    func run(using context: CommandContext) throws -> Future<Void> {
         let message = try context.argument("message")
         /// We can use requireOption here since both options have default values
         let eyes = try context.requireOption("eyes")


### PR DESCRIPTION
I've modified an example code in "Command" doc. Since the return value of `run` cannot be `Future` itself, you have to change it to take a type argument and conform to the signature, so I fix it by changing `Future` to `Future<Void>`.