### PR TITLE
Fix typo in sample code block

### DIFF
--- a/3.0/docs/fluent/migrations.md
+++ b/3.0/docs/fluent/migrations.md
@@ -181,7 +181,8 @@ struct AddGalaxyMass: <#Database#>Migration {
 
     static func revert(on conn: <#Database#>Connection) -> Future<Void> {
         return <#Database#>Database.update(Galaxy.self, on: conn) { builder in
-        builder.deleteField(for: \.mass)
+            builder.deleteField(for: \.mass)
+        }
     }
 }
 ```


### PR DESCRIPTION
This PR just corrects some indentation and adds a closing `}` that was missing. (Compare to the sample code block on lines 163-171.)