### PR TITLE
Middleware page for documentation

### DIFF
--- a/3.0/docs/vapor/middleware.md
+++ b/3.0/docs/vapor/middleware.md
@@ -52,4 +52,4 @@ The Vapor Auth package has middlewares that can do basic user validation, token 
 
 ## Middleware API
 
-Information on how middleware works and authoring custom middleware can be found in the [Vapor API Documentation](“https://api.vapor.codes/vapor/latest/Vapor/Protocols/Middleware.html).
+Information on how middleware works and authoring custom middleware can be found in the [Vapor API Documentation](https://api.vapor.codes/vapor/latest/Vapor/Protocols/Middleware.html).

--- a/3.0/docs/vapor/middleware.md
+++ b/3.0/docs/vapor/middleware.md
@@ -24,7 +24,7 @@ middlewares.use(FileMiddleware.self)
 services.register(middlewares)
 ```
 
-Now that the FileMiddleware is registered, an file like “Public/images/logo.png” can be linked from a Leaf template as `<img src="/images/logo.png"/>`.
+Now that the FileMiddleware is registered, a file like “Public/images/logo.png” can be linked from a Leaf template as `<img src="/images/logo.png"/>`.
 
 ## CORSMiddleware
 
@@ -44,7 +44,7 @@ config.use(corsConfiguration)
 services.register(middlewares)
 ```
 
-The CORSMiddleware must be listed at the top of your middlewares config.
+Given that thrown errors are immediately returned to the client, the CORSMiddleware must be listed before the ErrorMiddleware so that the errors can be received by browser clients.
 
 ## Authentication and Sessions Middleware
 

--- a/3.0/docs/vapor/middleware.md
+++ b/3.0/docs/vapor/middleware.md
@@ -47,7 +47,7 @@ middlewares.use(ErrorMiddleware.self)
 services.register(middlewares)
 ```
 
-Given that thrown errors are immediately returned to the client, the CORSMiddleware must be listed _before_ the `ErrorMiddleware`; otherwise the HTTP error response will be returned without CORS headers, and cannot be read by the browser.
+Given that thrown errors are immediately returned to the client, the `CORSMiddleware` must be listed _before_ the `ErrorMiddleware`; otherwise the HTTP error response will be returned without CORS headers, and cannot be read by the browser.
 
 ## Authentication and Sessions Middleware
 

--- a/3.0/docs/vapor/middleware.md
+++ b/3.0/docs/vapor/middleware.md
@@ -1,3 +1,56 @@
 # Middleware
 
-Coming soon.
+This guide will introduce you to middleware. Middlewares are a type of code that operate “in the middle” of a request coming in and out of the Vapor software.
+
+## Configuration
+
+Middleware is registered in your `config.swift` file. ErrorMiddleware is a very common example; it will take a thrown error in your software and convert it to a legible HTTP response code.
+
+```swift
+var middlewares = MiddlewareConfig()
+middlewares.use(ErrorMiddleware.self)
+middlewares.use(FileMiddleware.self)
+services.register(middlewares)
+```
+
+
+## FileMiddleware
+
+FileMiddleware enables serving assets from the Public folder of your project to clients. You might include static files like stylesheets or bitmap images here.
+
+```swift
+var middlewares = MiddlewareConfig()
+/* other registered middlewares */
+middlewares.use(FileMiddleware.self)
+services.register(middlewares)
+```
+
+Now that the FileMiddleware is registered, an file like “Public/images/logo.png” can be linked from a Leaf template as `<img src="/images/logo.png"/>`.
+
+## CORSMiddleware
+
+Cross-origin resource sharing (CORS) is a mechanism that allows restricted resources on a web page to be requested from another domain outside the domain from which the first resource was served. APIs built in Vapor will require a CORS policy in order to safely return requests to modern web browsers.
+
+An example configuration could look something like this:
+
+```swift
+var middlewares = MiddlewareConfig()
+let corsConfiguration = CORSMiddleware.Configuration(
+    allowedOrigin: .all,
+    allowedMethods: [.GET, .POST, .PUT, .OPTIONS, .DELETE, .PATCH],
+    allowedHeaders: [.accept, .authorization, .contentType, .origin, .xRequestedWith, .userAgent, .accessControlAllowOrigin]
+)
+let corsMiddleware = CORSMiddleware(configuration: corsConfiguration)
+config.use(corsConfiguration)
+services.register(middlewares)
+```
+
+The CORSMiddleware must be listed at the top of your middlewares config.
+
+## Authentication and Sessions Middleware
+
+The Vapor Auth package has middlewares that can do basic user validation, token validation, and manage sessions. See the [Auth](https://docs.vapor.codes/3.0/auth/getting-started/) documentation for an outline of the AuthMiddleware.
+
+## Middleware API
+
+Information on how middleware works and authoring custom middleware can be found in the [Vapor API Documentation](“https://api.vapor.codes/vapor/latest/Vapor/Protocols/Middleware.html).

--- a/3.0/docs/vapor/middleware.md
+++ b/3.0/docs/vapor/middleware.md
@@ -16,11 +16,10 @@ services.register(middlewares)
 
 ## FileMiddleware
 
-FileMiddleware enables serving assets from the Public folder of your project to clients. You might include static files like stylesheets or bitmap images here.
+FileMiddleware enables the serving assets from the Public folder of your project to clients. You might include static files like stylesheets or bitmap images here.
 
 ```swift
 var middlewares = MiddlewareConfig()
-/* other registered middlewares */
 middlewares.use(FileMiddleware.self)
 services.register(middlewares)
 ```

--- a/3.0/docs/vapor/middleware.md
+++ b/3.0/docs/vapor/middleware.md
@@ -1,10 +1,10 @@
 # Middleware
 
-This guide will introduce you to middleware. Middlewares are a type of code that operate “in the middle” of a request coming in and out of the Vapor software.
+Middleware is a logic chain between the client and a Vapor route handler. It allows you to make operations on incoming requests before they get to the route handler, and on outgoing responses before they go to the client.
 
 ## Configuration, and ErrorMiddleware
 
-Middleware is registered in your `config.swift` file. ErrorMiddleware is a very common example; it will take a thrown error in your software and convert it to a legible HTTP response code.
+Middleware is registered in your `config.swift` file. `ErrorMiddleware` is a very common example; it will take a thrown error in your software and convert it to a legible HTTP response code.
 
 ```swift
 var middlewares = MiddlewareConfig()
@@ -14,11 +14,11 @@ middlewares.use(FileMiddleware.self)
 services.register(middlewares)
 ```
 
-It is common to run several middlewares in a single project. These middlewares are stacked up, and then registered together. The order in which middleware are listed can sometimes matter (see CORSMiddleware below).
+You will often run several middlewares in a single project. These middlewares are stacked up, and then registered together. The order in which middleware are listed can sometimes matter (see `CORSMiddleware` below).
 
 ## FileMiddleware
 
-FileMiddleware enables the serving assets from the Public folder of your project to clients. You might include static files like stylesheets or bitmap images here.
+`FileMiddleware` enables the serving of assets from the Public folder of your project to the client. You might include static files like stylesheets or bitmap images here.
 
 ```swift
 var middlewares = MiddlewareConfig()
@@ -26,7 +26,7 @@ middlewares.use(FileMiddleware.self)
 services.register(middlewares)
 ```
 
-Now that the FileMiddleware is registered, a file like “Public/images/logo.png” can be linked from a Leaf template as `<img src="/images/logo.png"/>`.
+Now that the `FileMiddleware` is registered, a file like “Public/images/logo.png” can be linked from a Leaf template as `<img src="/images/logo.png"/>`.
 
 ## CORSMiddleware
 
@@ -47,11 +47,11 @@ middlewares.use(ErrorMiddleware.self)
 services.register(middlewares)
 ```
 
-Given that thrown errors are immediately returned to the client, the CORSMiddleware must be listed _before_ the ErrorMiddleware; otherwise the HTTP error response will be returned without CORS headers, and cannot be read by the browser.
+Given that thrown errors are immediately returned to the client, the CORSMiddleware must be listed _before_ the `ErrorMiddleware`; otherwise the HTTP error response will be returned without CORS headers, and cannot be read by the browser.
 
 ## Authentication and Sessions Middleware
 
-The Vapor Auth package has middlewares that can do basic user validation, token validation, and manage sessions. See the [Auth documentation](https://docs.vapor.codes/3.0/auth/getting-started/) for an outline of the AuthMiddleware.
+The Vapor Auth package has middlewares that can do basic user validation, token validation, and manage sessions. See the [Auth documentation](https://docs.vapor.codes/3.0/auth/getting-started/) for an outline of the `AuthMiddleware`.
 
 ## Middleware API
 

--- a/3.0/docs/vapor/middleware.md
+++ b/3.0/docs/vapor/middleware.md
@@ -30,7 +30,7 @@ Now that the FileMiddleware is registered, a file like “Public/images/logo.png
 
 ## CORSMiddleware
 
-Cross-origin resource sharing (CORS) is a mechanism that allows restricted resources on a web page to be requested from another domain outside the domain from which the first resource was served. APIs built in Vapor will require a CORS policy in order to safely return requests to modern web browsers.
+Cross-origin resource sharing (CORS) is a mechanism that allows restricted resources on a web page to be requested from another domain outside the domain from which the first resource was served. REST APIs built in Vapor will require a CORS policy in order to safely return requests to modern web browsers.
 
 An example configuration could look something like this:
 
@@ -47,7 +47,7 @@ middlewares.use(ErrorMiddleware.self)
 services.register(middlewares)
 ```
 
-Given that thrown errors are immediately returned to the client, the CORSMiddleware must be listed before the ErrorMiddleware so that the errors can be received by browser clients.
+Given that thrown errors are immediately returned to the client, the CORSMiddleware must be listed _before_ the ErrorMiddleware; otherwise the HTTP error response will be returned without CORS headers, and cannot be read by the browser.
 
 ## Authentication and Sessions Middleware
 

--- a/3.0/docs/vapor/middleware.md
+++ b/3.0/docs/vapor/middleware.md
@@ -2,7 +2,7 @@
 
 This guide will introduce you to middleware. Middlewares are a type of code that operate “in the middle” of a request coming in and out of the Vapor software.
 
-## Configuration
+## Configuration, and ErrorMiddleware
 
 Middleware is registered in your `config.swift` file. ErrorMiddleware is a very common example; it will take a thrown error in your software and convert it to a legible HTTP response code.
 
@@ -48,7 +48,7 @@ Given that thrown errors are immediately returned to the client, the CORSMiddlew
 
 ## Authentication and Sessions Middleware
 
-The Vapor Auth package has middlewares that can do basic user validation, token validation, and manage sessions. See the [Auth](https://docs.vapor.codes/3.0/auth/getting-started/) documentation for an outline of the AuthMiddleware.
+The Vapor Auth package has middlewares that can do basic user validation, token validation, and manage sessions. See the [Auth documentation](https://docs.vapor.codes/3.0/auth/getting-started/) for an outline of the AuthMiddleware.
 
 ## Middleware API
 

--- a/3.0/docs/vapor/middleware.md
+++ b/3.0/docs/vapor/middleware.md
@@ -10,9 +10,11 @@ Middleware is registered in your `config.swift` file. ErrorMiddleware is a very 
 var middlewares = MiddlewareConfig()
 middlewares.use(ErrorMiddleware.self)
 middlewares.use(FileMiddleware.self)
+// etc.
 services.register(middlewares)
 ```
 
+It is common to run several middlewares in a single project. These middlewares are stacked up, and then registered together. The order in which middleware are listed can sometimes matter (see CORSMiddleware below).
 
 ## FileMiddleware
 
@@ -40,7 +42,8 @@ let corsConfiguration = CORSMiddleware.Configuration(
     allowedHeaders: [.accept, .authorization, .contentType, .origin, .xRequestedWith, .userAgent, .accessControlAllowOrigin]
 )
 let corsMiddleware = CORSMiddleware(configuration: corsConfiguration)
-config.use(corsConfiguration)
+middlewares.use(corsMiddleware)
+middlewares.use(ErrorMiddleware.self)
 services.register(middlewares)
 ```
 


### PR DESCRIPTION
Describes FileMiddleware, ErrorMiddleware, CORSMiddleware, and a link out to the Auth library.

A future version of this document might describe the creation of custom Middlewares. In the meantime, a link to the API is provided.