### PR TITLE
Specify that conformance to `Content` is necessary before performing a query

### DIFF
--- a/3.0/docs/fluent/getting-started.md
+++ b/3.0/docs/fluent/getting-started.md
@@ -165,7 +165,13 @@ Server starting on http://localhost:8080
 
 ## Performing a Query
 
-Now that you have created a model and a corresponding schema in your database, let's make your first query.
+First, we must ensure that our `User` object conforms to the `Content` type. This will ensure that the object can be encoded and decoded from HTTP messages. You get this conformance for free with any `Model` objects, so implementing this is straightforward:
+
+```swift
+extension User: Content { }
+```
+
+Now that you have created a model, made it conform to `Content` and created a corresponding schema in your database, let's make your first query.
 
 ```swift
 router.get("users") { req in

--- a/3.0/docs/fluent/getting-started.md
+++ b/3.0/docs/fluent/getting-started.md
@@ -79,9 +79,13 @@ final class User: <#Database#>Model {
         self.age = age
     }
 }
+
+extension User: Content { }
 ```
 
 The example above shows a simple model representing a user. You can make both structs and classes a model. You can even conform types that come from external modules. The only requirement is that these types conform to `Codable`, which must be declared on the base type for synthesized (automatic) conformance.
+
+*Note:* `Content` conformance will ensure that the object can be encoded and decoded from HTTP messages. This will be necessary when performing a query.
 
 Take a look at [Fluent &rarr; Model](models.md) for more information on creating models with custom ID types and keys.
 
@@ -164,14 +168,6 @@ Server starting on http://localhost:8080
 ```
 
 ## Performing a Query
-
-First, we must ensure that our `User` object conforms to the `Content` type. This will ensure that the object can be encoded and decoded from HTTP messages. You get this conformance for free with any `Model` objects, so implementing this is straightforward:
-
-```swift
-extension User: Content { }
-```
-
-Now that you have created a model, made it conform to `Content` and created a corresponding schema in your database, let's make your first query.
 
 ```swift
 router.get("users") { req in


### PR DESCRIPTION
I had followed the steps as described in the Getting Started (with Fluent) documentation, but in the end I was receiving a tricky to debug error:

```
Cannot convert value of type '(DatabaseConnectable) -> EventLoopFuture<[User]>' to expected argument type '(Request) -> _'
```

I figured this is because the returned type needs to be parsed to something that can be transferred over HTTP. Conforming to the `Content` type solved this.