### PR TITLE
Adds code to fix an error I have run into when attempting to migrate a database table

### DIFF
--- a/3.0/docs/fluent/migrations.md
+++ b/3.0/docs/fluent/migrations.md
@@ -178,11 +178,11 @@ struct AddGalaxyMass: <#Database#>Migration {
 Since we declared our `mass` property non-optional (`Int`), we will have to add a special configuration that declares its default value as well. In SQL, this is equivalent to the `DEFAULT` keyword. Therefore, to fix the error, the above code would become:
 
 ```swift
-struct AddGalaxyMass: <#Database#>Migration {
-    // ... 
+struct AddGalaxyMass: SQLiteMigration {
+    // ...
 
-    static func prepare(on conn: <#Database#>Connection) -> Future<Void> {
-        return <#Database#>Database.update(Galaxy.self, on: conn) { builder in
+    static func prepare(on conn: SQLiteConnection) -> Future<Void> {
+        return SQLiteDatabase.update(Galaxy.self, on: conn) { builder in
             let defaultValueConstraint = SQLiteColumnConstraint.default(.literal(0))
             builder.field(for: \.mass, type: .integer, defaultValueConstraint)
         }

--- a/3.0/docs/fluent/migrations.md
+++ b/3.0/docs/fluent/migrations.md
@@ -157,7 +157,7 @@ struct AddGalaxyMass: <#Database#>Migration {
 }
 ```
 
-Our prepare method will look very similar to the prepare method for a new table, except it will only contain our newly added field.
+Our prepare method will look very similar to the prepare method for a new table, except it will only contain our newly added field. 
 
 ```swift
 struct AddGalaxyMass: <#Database#>Migration {
@@ -166,6 +166,25 @@ struct AddGalaxyMass: <#Database#>Migration {
     static func prepare(on conn: <#Database#>Connection) -> Future<Void> {
         return <#Database#>Database.update(Galaxy.self, on: conn) { builder in
             builder.field(for: \.mass)
+        }
+    }
+}
+```
+
+*Note:* In SQLite and maybe other databases that have strict NULL / NOT NULL constraint, you may receive the following error:
+
+> Cannot add a NOT NULL column with default value NULL
+
+Since we declared our `mass` property non-optional (`Int`), we will have to add a special configuration that declares its default value as well. In SQL, this is equivalent to the `DEFAULT` keyword. Therefore, to fix the error, the above code would become:
+
+```swift
+struct AddGalaxyMass: <#Database#>Migration {
+    // ... 
+
+    static func prepare(on conn: <#Database#>Connection) -> Future<Void> {
+        return <#Database#>Database.update(Galaxy.self, on: conn) { builder in
+            let defaultValueConstraint = SQLiteColumnConstraint.default(.literal(0))
+            builder.field(for: \.mass, type: .integer, defaultValueConstraint)
         }
     }
 }


### PR DESCRIPTION
Was getting the `Cannot add a NOT NULL column with default value NULL` error when attempting to perform a migration. Fluent correctly choses `notNull` for the column to be added (in this case `mass`), since it is being declared as a non-optional, however, at least in SQLite (not sure about other databases), NOT NULL values must have a default value.

Adding the configuration fixes this problem.