### PR TITLE
Add mention of the need to enable FileMiddleware

### DIFF
--- a/3.0/docs/getting-started/structure.md
+++ b/3.0/docs/getting-started/structure.md
@@ -38,6 +38,10 @@ the file immediately.
 For example, a request to `localhost:8080/favicon.ico` will check to see
 if `Public/favicon.ico` exists. If it does, Vapor will return it.
 
+You will need to enable `FileMiddleware` in your `configure.swift` file before Vapor can return public files. Make sure you've uncommented this line:
+
+`middlewares.use(FileMiddleware.self)`
+
 ## Sources
 
 This folder contains all of the Swift source files for your project. 


### PR DESCRIPTION
Related to [this issue](https://github.com/vapor/vapor/issues/1629#issuecomment-451648426), the docs don't mention the need to enable `FileMiddleware` or how to do so when talking about Vapor returning public files.