### PR TITLE
[Reference links] - Fix lots of broken links

### DIFF
--- a/3.0/docs/auth/getting-started.md
+++ b/3.0/docs/auth/getting-started.md
@@ -1,6 +1,6 @@
 # Getting Started with Auth
 
-Auth ([vapor/auth](https://github.com/vapor/auth)) is a framework for adding authentication to your application. It builds on top of [Fluent](../fluent/getting-started) by using models as the basis of authentication. 
+Auth ([vapor/auth](https://github.com/vapor/auth)) is a framework for adding authentication to your application. It builds on top of [Fluent](../fluent/getting-started.md) by using models as the basis of authentication. 
 
 !!! tip
     There is a Vapor API template with Auth pre-configured available.

--- a/3.0/docs/crypto/otp.md
+++ b/3.0/docs/crypto/otp.md
@@ -22,7 +22,7 @@ let code = HOTP.SHA1.generate(secret: "hi", counter: 0)
 print(code) "208503"
 ```
 
-View the API docs for [`TOTP`](#fixme) and [`HOTP`](#fixme) for more information.
+View the API docs for [`TOTP`](https://api.vapor.codes/crypto/latest/Crypto/Structs/TOTP.html) and [`HOTP`](https://api.vapor.codes/crypto/latest/Crypto/Structs/HOTP.html) for more information.
 
 ## Base 32
 
@@ -38,4 +38,4 @@ let secret: Data = ...
 let encodedSecret = secret.base32EncodedString()
 ```
 
-See Crypto's [`Data`](#fixme) extensions for more information. 
+See Crypto's [`Data`](https://api.vapor.codes/crypto/latest/Crypto/Extensions/Data.html) extensions for more information. 

--- a/3.0/docs/fluent/querying.md
+++ b/3.0/docs/fluent/querying.md
@@ -16,7 +16,7 @@ router.get("galaxies") { req in
 }
 ```
 
-You can use convenience methods on a `Container` to create connections manually. Learn more about that in [DatabaseKit &rarr; Overview &rarr; Connections](../database-kit/overview/#connections).
+You can use convenience methods on a `Container` to create connections manually. Learn more about that in [DatabaseKit &rarr; Overview &rarr; Connections](../database-kit/overview.md#connections).
 
 ## Create
 

--- a/3.0/docs/fluent/transaction.md
+++ b/3.0/docs/fluent/transaction.md
@@ -4,7 +4,7 @@ Transactions allow you to ensure multiple operations complete succesfully before
 
 To perform a transaction, you need access to something that can connect to the database. This is usually an incoming HTTP request. Use the [`transaction(on:_:)`](https://api.vapor.codes/fluent/latest/Fluent/Extensions/DatabaseConnectable.html#/s:11DatabaseKit0A11ConnectableP6FluentE11transaction2on_3NIO15EventLoopFutureCyqd_0_GAA0A10IdentifierVyqd__G_AJ10ConnectionQyd__KctAD21TransactionSupportingRd__r0_lF) method.
 
-Fill in the Xcode placeholders below with your database's name from [Getting Started &rarr; Choosing a Driver](getting-started/#choosing-a-driver).
+Fill in the Xcode placeholders below with your database's name from [Getting Started &rarr; Choosing a Driver](getting-started.md#choosing-a-driver).
 
 ```swift
 req.transaction(on: .<#dbid#>) { conn in

--- a/3.0/docs/getting-started/structure.md
+++ b/3.0/docs/getting-started/structure.md
@@ -5,7 +5,7 @@ you familiar with where things go.
 
 ## Folder Structure
 
-Vapor's folder structure builds on top of [SPM's folder structure](spm#folder-structure).
+Vapor's folder structure builds on top of [SPM's folder structure](spm.md#folder-structure).
 
 ```
 .
@@ -46,7 +46,7 @@ You will need to enable `FileMiddleware` in your `configure.swift` file before V
 
 This folder contains all of the Swift source files for your project. 
 The top level folders (`App` and `Run`) reflect your package's modules, 
-as declared in the [package manifest](spm#targets).
+as declared in the [package manifest](spm.md#targets).
 
 ### App
 

--- a/3.0/docs/getting-started/structure.md
+++ b/3.0/docs/getting-started/structure.md
@@ -64,7 +64,7 @@ have many functions that accept a request and return some sort of response.
 #### Models
 
 The `Models` folder is a great place to store your [`Content`](content.md) structs or
-Fluent [`Model`](../fluent/models.md)s.
+Fluent [`Models`](../fluent/models.md).
 
 #### boot.swift
 

--- a/3.0/docs/getting-started/structure.md
+++ b/3.0/docs/getting-started/structure.md
@@ -64,7 +64,7 @@ have many functions that accept a request and return some sort of response.
 #### Models
 
 The `Models` folder is a great place to store your [`Content`](content.md) structs or
-Fluent [`Models`](../fluent/models.md).
+Fluent [`Model`s](../fluent/models.md).
 
 #### boot.swift
 

--- a/3.0/docs/http/client.md
+++ b/3.0/docs/http/client.md
@@ -22,7 +22,7 @@ print(httpRes) // HTTPResponse
 Take note that we are passing the _hostname_. This is different from a full URL. You can use `URL` and `URLComponents` from Foundation to parse out a hostname. Vapor's convenience APIs do this automatically.
 
 !!! warning
-    This guide assumes you are on the main thread. Don't use `wait()` if you are inside of a route closure. See [Async &rarr; Overview](../async/overview/#blocking) for more information.
+    This guide assumes you are on the main thread. Don't use `wait()` if you are inside of a route closure. See [Async &rarr; Overview](../async/overview.md#blocking) for more information.
 
 After we have a connected HTTP client, we can send an [`HTTPRequest`](https://api.vapor.codes/http/latest/HTTP/Structs/HTTPRequest.html) using [`send(...)`](https://api.vapor.codes/http/latest/HTTP/Classes/HTTPClient.html#/s:4HTTP10HTTPClientC4sendXeXeF). This will return an  [`HTTPResponse`](https://api.vapor.codes/http/latest/HTTP/Structs/HTTPResponse.html) containing the headers and body sent back from the server. See [HTTP &rarr; Message](message.md) for more information on HTTP messages. 
 

--- a/3.0/docs/redis/overview.md
+++ b/3.0/docs/redis/overview.md
@@ -89,4 +89,4 @@ router.get("get") { req -> Future<String> in
 }
 ```
 
-See [DatabaseKit &rarr; Overview](../database-kit/overview/#keyed-cache) for more information.
+See [DatabaseKit &rarr; Overview](../database-kit/overview.md#keyed-cache) for more information.

--- a/3.0/docs/routing/overview.md
+++ b/3.0/docs/routing/overview.md
@@ -5,7 +5,7 @@ Routing ([vapor/routing](https://github.com/vapor/routing)) is a small framework
 !!! tip
     If you use Vapor, most of Routing's APIs will be wrapped by more convenient methods. See [Vapor → Routing] for more information.
 
-This guide will show you how to register a static route and a dynamic route and how to use [`Parameter`](https://api.vapor.codes/routing/latest/Routing/Protocols/Parameter.html)s.
+This guide will show you how to register a static route and a dynamic route and how to use [`Parameters`](https://api.vapor.codes/routing/latest/Routing/Protocols/Parameter.html).
 
 ## Register
 

--- a/3.0/docs/routing/overview.md
+++ b/3.0/docs/routing/overview.md
@@ -5,7 +5,7 @@ Routing ([vapor/routing](https://github.com/vapor/routing)) is a small framework
 !!! tip
     If you use Vapor, most of Routing's APIs will be wrapped by more convenient methods. See [Vapor → Routing] for more information.
 
-This guide will show you how to register a static route and a dynamic route and how to use [`Parameters`](https://api.vapor.codes/routing/latest/Routing/Protocols/Parameter.html).
+This guide will show you how to register a static route and a dynamic route and how to use [`Parameter`s](https://api.vapor.codes/routing/latest/Routing/Protocols/Parameter.html).
 
 ## Register
 

--- a/3.0/docs/service/provider.md
+++ b/3.0/docs/service/provider.md
@@ -9,7 +9,7 @@ Providers can:
 
 ## Register
 
-Once you have added a Service-exposing [SPM dependency](../getting-started/spm/#dependencies) to your project, adding the provider is easy.
+Once you have added a Service-exposing [SPM dependency](../getting-started/spm.md#dependencies) to your project, adding the provider is easy.
 
 ```swift
 import Foo
@@ -17,7 +17,7 @@ import Foo
 try services.register(FooProvider())
 ```
 
-This is usually done in [`configure.swift`](../getting-started/structure/#configureswift). 
+This is usually done in [`configure.swift`](../getting-started/structure.md#configureswift). 
 
 !!! note
 	You can search GitHub for the [`vapor-service`](https://github.com/topics/vapor-service) tag for a list of packages that expose services using this method.

--- a/3.0/docs/service/services.md
+++ b/3.0/docs/service/services.md
@@ -17,7 +17,7 @@ It's an empty protocol so there should be no missing requirements.
 
 ### Factory
 
-Now the service can be registered to the [`Services`](https://api.vapor.codes/service/latest/Service/Structs/Services.html) struct. This is usually done in [`configure.swift`](../getting-started/structure/#configureswift).
+Now the service can be registered to the [`Services`](https://api.vapor.codes/service/latest/Service/Structs/Services.html) struct. This is usually done in [`configure.swift`](../getting-started/structure.md#configureswift).
 
 ```swift
 services.register(Logger.self) { container in
@@ -81,7 +81,7 @@ default: config.prefer(PrintLogger.self, for: Logger.self)
 }
 ```
 
-Here we are using the [`Environment`](https://api.vapor.codes/service/latest/Service/Structs/Environment.html) to dynamically prefer a service. This is usually done in [`configure.swift`](../getting-started/structure/#configureswift).
+Here we are using the [`Environment`](https://api.vapor.codes/service/latest/Service/Structs/Environment.html) to dynamically prefer a service. This is usually done in [`configure.swift`](../getting-started/structure.md#configureswift).
 
 !!! note
 	You can also dynamically _register_ services based on environment instead of using service config. 

--- a/3.0/docs/sql/overview.md
+++ b/3.0/docs/sql/overview.md
@@ -26,7 +26,7 @@ router.get("sql") { req in
 }
 ```
 
-Check out [Database Kit &rarr; Overview &rarr; Connections](../database-kit/overview.md/#connections) for more information. The rest of this guide will assume you have access to a SQL database connection.
+Check out [Database Kit &rarr; Overview &rarr; Connections](../database-kit/overview.md#connections) for more information. The rest of this guide will assume you have access to a SQL database connection.
 
 ## Select
 

--- a/3.0/docs/websocket/getting-started.md
+++ b/3.0/docs/websocket/getting-started.md
@@ -1,6 +1,6 @@
 # Getting Started with WebSocket
 
-WebSocket ([vapor/websocket](https://github.com/vapor/websocket)) is a non-blocking, event-driven WebSocket library built on SwiftNIO. It makes working with SwiftNIO's WebSocket handlers easy and provides integration with [HTTP](../http/getting-started) clients and servers. Creating a WebSocket echo server takes just a few lines of code.
+WebSocket ([vapor/websocket](https://github.com/vapor/websocket)) is a non-blocking, event-driven WebSocket library built on SwiftNIO. It makes working with SwiftNIO's WebSocket handlers easy and provides integration with [HTTP](../http/getting-started.md) clients and servers. Creating a WebSocket echo server takes just a few lines of code.
 
 !!! tip
     If you use Vapor, most of WebSocket's APIs will be wrapped by more convenient methods. 


### PR DESCRIPTION
Fix lots of broken reference links across the entire v3.0 documentation.

**Nit:**
About the `s` fixits, I don't know what the 'standard' is. If 
[`word`]<url>s
or
[`words`]<url>

I prefer the latter since the complete word gets the link highlighting. Since I don't know if this there's another reason why not use always the latter, I just fixed two of those cases [there is no consistency across the docs].