### PR TITLE
fix incorrect pattern name DI -> Service Locator

### DIFF
--- a/3.0/docs/getting-started/services.md
+++ b/3.0/docs/getting-started/services.md
@@ -1,6 +1,6 @@
 # Services
 
-Services is a dependency injection (also called inversion of control) framework for Vapor. The services framework allows you to register, configure, and initialize anything you might need in your application.
+Services is a Service Locator (sometimes called inversion of control) framework for Vapor. The services framework allows you to register, configure, and initialize anything you might need in your application.
 
 ## Container
 


### PR DESCRIPTION
As fowler discusses here

[Inversion of Control Containers and the Dependency Injection pattern](https://martinfowler.com/articles/injection.html#UsingAServiceLocator)

Dependency Injection and Service Locator are different things. If I understand correctly a service locator is passed into the object in question and it then has to request the service it needs from it. Dependency injection would have the objects dependencies automatically injected in through its initialiser or setters. In this case I think we are using a Service Locator.