### PR TITLE
Vapor repo needs to be tapped before installing with Homebrew

### DIFF
--- a/3.0/docs/install/macos.md
+++ b/3.0/docs/install/macos.md
@@ -35,6 +35,7 @@ Now that you have Swift 4.1, let's install the [Vapor Toolbox](../getting-starte
 The toolbox includes all of Vapor's dependencies as well as a handy CLI tool for creating new projects.
 
 ```sh
+brew tap vapor/tap
 brew install vapor/tap/vapor
 ```
 


### PR DESCRIPTION
Added the command `brew tap vapor/tap` to the installation instructions, as Homebrew cannot find Vapor without this command.