### PR TITLE
Cannot use `id` in Swift

### DIFF
--- a/3.0/docs/getting-started/routing.md
+++ b/3.0/docs/getting-started/routing.md
@@ -40,7 +40,7 @@ public func routes(_ router: Router) throws {
     router.get("hello") { req in
         return "Hello, world!"
     }
-  
+
     /// ...
 }
 ```
@@ -50,12 +50,12 @@ See [Getting Started &rarr; Content](content.md) for more information about what
 ## Parameters
 
 Sometimes you may want one of the components of your route path to be dynamic. This is often used when
-you want to get an item with a supplied identifier, e.g., `GET /users/:id`
+you want to get an item with a supplied identifier, e.g., `GET /users/:uid`
 
 ```swift
 router.get("users", Int.parameter) { req -> String in
-    let id = try req.parameters.next(Int.self)
-    return "requested id #\(id)"
+    let uid = try req.parameters.next(Int.self)
+    return "requested user id #\(uid)"
 }
 ```
 


### PR DESCRIPTION
Prevent this when doing a direct copy-paste:

`error: 'id' is unavailable in Swift: 'id' is not available in Swift; use 'Any'`

Found some details on the [Swift blog](https://developer.apple.com/swift/blog/?id=39)